### PR TITLE
fix(units): arm the heartbeat timer across reboots, drop the builder's home path

### DIFF
--- a/config/systemd/ruos-agent-nightly.service
+++ b/config/systemd/ruos-agent-nightly.service
@@ -6,10 +6,10 @@ After=ruvultra-brain.service ruvultra-embedder.service
 Type=oneshot
 ExecStart=/bin/bash -c '\
   curl -s -X POST http://127.0.0.1:9876/brain/checkpoint && \
-  curl -s "http://127.0.0.1:9876/brain/export-pairs?format=jsonl&limit=10000" > /home/ruvultra/brain-data/training/pairs-$(date +%%Y%%m%%d).jsonl && \
-  /home/ruvultra/.local/bin/ruos-agent --train && \
-  /home/ruvultra/.local/bin/ruos-agent --backfill && \
-  /home/ruvultra/.local/bin/ruos-agent --eval'
+  curl -s "http://127.0.0.1:9876/brain/export-pairs?format=jsonl&limit=10000" > %h/brain-data/training/pairs-$(date +%%Y%%m%%d).jsonl && \
+  %h/.local/bin/ruos-agent --train && \
+  %h/.local/bin/ruos-agent --backfill && \
+  %h/.local/bin/ruos-agent --eval'
 StandardOutput=journal
 StandardError=journal
 TimeoutStartSec=600

--- a/config/systemd/ruos-agent.service
+++ b/config/systemd/ruos-agent.service
@@ -5,7 +5,7 @@ Wants=ruvultra-brain.service ruvultra-embedder.service
 
 [Service]
 Type=oneshot
-ExecStart=/home/ruvultra/.local/bin/ruos-agent
+ExecStart=%h/.local/bin/ruos-agent
 StandardOutput=journal
 StandardError=journal
 TimeoutStartSec=120

--- a/config/systemd/ruos-agent.timer
+++ b/config/systemd/ruos-agent.timer
@@ -2,9 +2,20 @@
 Description=ruos-agent heartbeat — every 5 minutes
 
 [Timer]
-OnBootSec=60
-OnUnitActiveSec=300
+# Use a calendar expression rather than OnBootSec=/OnUnitActiveSec=.
+#
+# The monotonic pair could not re-arm across a reboot: OnUnitActiveSec= has no
+# anchor until the service has been activated at least once in the current
+# runtime, so if the OnBootSec= trigger did not produce an activation the timer
+# settled into "active (elapsed)" with "Trigger: n/a" and the heartbeat stopped
+# for good — silently, because an elapsed timer is not a failed unit.
+#
+# Persistent= was also inert here: it only applies to OnCalendar=, so the stamp
+# file under ~/.local/share/systemd/timers was written but never acted on.
+# With OnCalendar= it now does what it says and catches up a missed window.
+OnCalendar=*:0/5
 Persistent=true
+AccuracySec=30s
 
 [Install]
 WantedBy=timers.target

--- a/config/systemd/ruos-llm.service
+++ b/config/systemd/ruos-llm.service
@@ -4,7 +4,7 @@ After=ruvultra-brain.service ruvultra-embedder.service
 
 [Service]
 Type=simple
-ExecStart=/home/ruvultra/.local/bin/ruos-llm-serve --model Qwen/Qwen2.5-3B-Instruct --port 8080
+ExecStart=%h/.local/bin/ruos-llm-serve --model Qwen/Qwen2.5-3B-Instruct --port 8080
 StandardOutput=journal
 StandardError=journal
 Restart=on-failure

--- a/config/systemd/ruos-update.service
+++ b/config/systemd/ruos-update.service
@@ -4,7 +4,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/home/ruvultra/.local/bin/ruos-update --check
+ExecStart=%h/.local/bin/ruos-update --check
 StandardOutput=journal
 StandardError=journal
 TimeoutStartSec=120


### PR DESCRIPTION
Closes #5.

## What changed

**`ruos-agent.timer` — replaced the monotonic pair with a calendar expression.**

```diff
-OnBootSec=60
-OnUnitActiveSec=300
+OnCalendar=*:0/5
 Persistent=true
+AccuracySec=30s
```

`OnUnitActiveSec=` has no anchor until the service has been activated once in
the current runtime. When the `OnBootSec=` trigger produced no activation there
was nothing to count from, `NextElapse` went to `infinity`, and
`RemainAfterElapse=yes` left the unit reading as `active (elapsed)` forever.
Nothing alerts on that, because an elapsed timer is not a failed unit.

**Four units — `%h` instead of the packager's home directory.**

`ruos-agent.service`, `ruos-llm.service`, `ruos-update.service` and
`ruos-agent-nightly.service` all had `/home/<builder>/...` baked into
`ExecStart=`. As shipped they only worked for a user with the packager's account
name.

## Verification

Both states measured on the affected box, systemd 255 / Ubuntu 24.04.4, using a
drop-in so the two configs could be compared directly.

Before — after a plain `systemctl --user restart ruos-agent.timer`:

```
Active: active (elapsed) since Thu 2026-08-27 08:01:20 CEST
Trigger: n/a
NextElapseUSecMonotonic=infinity
LastTriggerUSec=Sat 2026-08-22 16:02:12 CEST
```

After, same command, no manual service start:

```
Active: active (waiting) since Thu 2026-08-27 08:07:36 CEST
Trigger: Thu 2026-08-27 08:10:00 CEST; 2min 21s left
TimersCalendar={ OnCalendar=*-*-* *:00/5:00 ; next_elapse=Thu 2026-08-27 08:10:00 CEST }
Persistent=yes
```

`systemd-analyze verify --user config/systemd/ruos-agent.timer` is clean, and
`systemd-analyze calendar '*:0/5'` normalizes to `*-*-* *:00/5:00`.

## Not covered here

`AccuracySec=30s` is new. The default is 1 minute, which on a 5-minute heartbeat
means up to 20% jitter; 30s keeps the loop closer to its stated cadence without
waking the box more than it already does. Say the word if you would rather leave
it at the default.
