### PR TITLE
fix(llm): stop hardcoding the build machine's interpreter in the shebang

### DIFF
--- a/packages/ruos-agent/ruos-llm-serve
+++ b/packages/ruos-agent/ruos-llm-serve
@@ -1,4 +1,4 @@
-#!/home/ruvultra/ml-env/bin/python3
+#!/usr/bin/env python3
 """ruos-llm-serve — local LLM inference server for ruos-agent.
 
 Serves Qwen2.5-3B-Instruct on CUDA via HuggingFace transformers.
@@ -9,10 +9,21 @@ Usage:
   ruos-llm-serve --model Qwen/Qwen2.5-3B-Instruct --port 8080
 """
 
-import argparse
-import json
 import os
 import sys
+
+# Prefer the ML virtualenv when it exists — torch and transformers live there —
+# but never bake it into the shebang. This file used to start with
+# "#!/home/<builder>/ml-env/bin/python3", which made it unrunnable on every
+# machine except the one that built the package: the kernel could not find the
+# interpreter, so the unit died at status=203/EXEC with no useful message.
+_VENV = os.path.expanduser("~/ml-env/bin/python3")
+if os.path.exists(_VENV) and not os.environ.get("RUOS_LLM_REEXEC"):
+    os.environ["RUOS_LLM_REEXEC"] = "1"
+    os.execv(_VENV, [_VENV, os.path.abspath(__file__)] + sys.argv[1:])
+
+import argparse
+import json
 import time
 import uuid
 from http.server import HTTPServer, BaseHTTPRequestHandler


### PR DESCRIPTION
Part of #4 — the shebang half.

## What changed

```diff
-#!/home/<builder>/ml-env/bin/python3
+#!/usr/bin/env python3
```

plus a guarded re-exec at the top of the module, so the ML virtualenv is still
preferred when it exists:

```python
_VENV = os.path.expanduser("~/ml-env/bin/python3")
if os.path.exists(_VENV) and not os.environ.get("RUOS_LLM_REEXEC"):
    os.environ["RUOS_LLM_REEXEC"] = "1"
    os.execv(_VENV, [_VENV, os.path.abspath(__file__)] + sys.argv[1:])
```

The env guard means the exec cannot loop if `~/ml-env/bin/python3` is itself a
wrapper.

## Verification

Same box, before and after:

```
# shipped v1.1.0 copy
$ /usr/local/bin/ruos-llm-serve --help
timeout: failed to run command '/usr/local/bin/ruos-llm-serve': No such file or directory

# this branch, on a host with no ~/ml-env
$ ./ruos-llm-serve --help
usage: ruos-llm-serve [-h] [--model MODEL] [--port PORT]
options:
  -h, --help     show this help message and exit
  --model MODEL
  --port PORT
```

`ast.parse` on the file is clean.

## Not covered here

This makes the script *start*. It does not give it torch — on a host without
`~/ml-env` it will still fail on the import, just with an error that names the
missing module instead of a missing interpreter. The rest of #4 (declaring or
shipping the ML environment, and the unconditional `source $ML_ENV` in
`ruos-agent --train`) is a separate decision about how that environment should
exist at all, so I have left it for an owner call rather than guessing.
